### PR TITLE
chore: set release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,9 +114,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  {
   "release": {
     "branches": ["main"]
   }
-}
 }

--- a/package.json
+++ b/package.json
@@ -113,5 +113,10 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  {
+  "release": {
+    "branches": ["main"]
   }
+}
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds a configuration for release branches to specify that releases should be made from the `main` branch.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R116-R120): Added a `release` configuration specifying that releases should be made from the `main` branch.