### PR TITLE
fix: fix releases again

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -11,14 +11,6 @@
                 "changelogFile": "CHANGELOG.md"
             }
         ],
-        [
-            "@semantic-release/git",
-            {
-                "assets": [
-                    "CHANGELOG.md"
-                ]
-            }
-        ],
         "@semantic-release/github"
 
     ]


### PR DESCRIPTION
This pull request includes a change to the `.releaserc` file to streamline the release process by removing the `@semantic-release/git` plugin configuration.

Simplification of release process:

* [`.releaserc`](diffhunk://#diff-644a8fae29c8e8b6ad5405a2e66c718a3b27f2e12581b7c5e00396d32b3e5cdeL14-L21): Removed the `@semantic-release/git` plugin configuration to streamline the release process.